### PR TITLE
Fixed found devices sometimes never appearing on the Dart side under iOS

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    api 'com.google.android.gms:play-services-nearby:17.0.0'
+    api 'com.google.android.gms:play-services-nearby:18.5.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.android.gms:play-services-location:17.1.0'
     implementation 'androidx.core:core-ktx:1.9.0'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -13,8 +13,8 @@
 
     <uses-feature android:name="android.hardware.wifi.direct" />
 
-    <uses-permission android:maxSdkVersion="28" android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:minSdkVersion="29" android:maxSdkVersion="31" android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+
     <uses-permission android:minSdkVersion="31" android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:minSdkVersion="31" android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:minSdkVersion="31" android:name="android.permission.BLUETOOTH_SCAN" />
@@ -28,6 +30,7 @@
         <service
             android:name=".NearbyService"
             android:enabled="true"
+            android:foregroundServiceType="connectedDevice"
             android:exported="false"/>
 
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -13,11 +13,16 @@
 
     <uses-feature android:name="android.hardware.wifi.direct" />
 
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:maxSdkVersion="28" android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:minSdkVersion="29" android:maxSdkVersion="31" android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+    <uses-permission android:minSdkVersion="31" android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:minSdkVersion="31" android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:minSdkVersion="31" android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:minSdkVersion="32" android:name="android.permission.NEARBY_WIFI_DEVICES" />
 
     <application>
         <service

--- a/android/src/main/kotlin/com/nankai/flutter_nearby_connections/FlutterNearbyConnectionsPlugin.kt
+++ b/android/src/main/kotlin/com/nankai/flutter_nearby_connections/FlutterNearbyConnectionsPlugin.kt
@@ -136,9 +136,11 @@ class FlutterNearbyConnectionsPlugin : FlutterPlugin, MethodCallHandler, Activit
 
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
-        serviceBindManager.mService?.stopAdvertising()
-        serviceBindManager.mService?.stopDiscovery()
-        serviceBindManager.unbindService()
+        if (this::serviceBindManager.isInitialized) {
+            serviceBindManager.mService?.stopAdvertising()
+            serviceBindManager.mService?.stopDiscovery()
+            serviceBindManager.unbindService()
+        }
         locationHelper = null
         exitProcess(0)
     }

--- a/android/src/main/kotlin/com/nankai/flutter_nearby_connections/LocationHelper.kt
+++ b/android/src/main/kotlin/com/nankai/flutter_nearby_connections/LocationHelper.kt
@@ -34,6 +34,10 @@ class LocationHelper(private val activity: Activity) : PluginRegistry.ActivityRe
                 Manifest.permission.BLUETOOTH_ADMIN,
                 Manifest.permission.ACCESS_WIFI_STATE,
                 Manifest.permission.CHANGE_WIFI_STATE,
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.NEARBY_WIFI_DEVICES,
                 Manifest.permission.ACCESS_COARSE_LOCATION,
                 Manifest.permission.ACCESS_FINE_LOCATION), REQUEST_LOCATION_PERMISSION)
     }

--- a/android/src/main/kotlin/com/nankai/flutter_nearby_connections/NearbyService.kt
+++ b/android/src/main/kotlin/com/nankai/flutter_nearby_connections/NearbyService.kt
@@ -52,7 +52,7 @@ class NearbyService : Service() {
     }
 
     fun startAdvertising(strategy: Strategy, deviceName: String) {
-        Log.d(TAG, "startAdvertising()")
+        Log.d(TAG, "startAdvertising($strategy, $deviceName)")
         connectionsClient.startAdvertising(
             deviceName, SERVICE_ID, callbackUtils.connectionLifecycleCallback,
             AdvertisingOptions.Builder().setStrategy(strategy).build()
@@ -60,7 +60,7 @@ class NearbyService : Service() {
     }
 
     fun startDiscovery(strategy: Strategy) {
-        Log.d(TAG, "startDiscovery()")
+        Log.d(TAG, "startDiscovery($strategy)")
         connectionsClient.startDiscovery(
             SERVICE_ID, callbackUtils.endpointDiscoveryCallback,
             DiscoveryOptions.Builder().setStrategy(strategy).build()

--- a/android/src/main/kotlin/com/nankai/flutter_nearby_connections/NearbyService.kt
+++ b/android/src/main/kotlin/com/nankai/flutter_nearby_connections/NearbyService.kt
@@ -92,10 +92,12 @@ class NearbyService : Service() {
     }
 
     override fun onDestroy() {
+        if (this::connectionsClient.isInitialized) {
+            stopAdvertising()
+            stopDiscovery()
+            connectionsClient.stopAllEndpoints()
+        }
         super.onDestroy()
-        stopAdvertising()
-        stopDiscovery()
-        connectionsClient.stopAllEndpoints()
     }
 
     private fun getNotification(): Notification? {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.nankai.flutter_nearby_connections_example"
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="flutter_nearby_connections_example"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -15,7 +15,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -29,6 +29,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/ios/Classes/MPCManager.swift
+++ b/ios/Classes/MPCManager.swift
@@ -167,6 +167,9 @@ extension MPCManager: MCNearbyServiceBrowserDelegate {
     func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
         // found peer, create a device with this peerID
         addNewDevice(for: peerID)
+        
+        // Inform about changed device state via NotificationCenter to guarantee main thread execution.
+        NotificationCenter.default.post(name: MPCManager.Notifications.deviceDidChangeState, object: nil)
     }
     
     func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {

--- a/lib/src/nearby_service.dart
+++ b/lib/src/nearby_service.dart
@@ -113,8 +113,12 @@ class NearbyService {
   /// The [startAdvertisingPeer] publishes an advertisement for a specific service
   /// that your app provides through the flutter_nearby_connections plugin and
   /// notifies its delegate about invitations from nearby peers.
-  FutureOr<dynamic> startAdvertisingPeer() async {
-    await _channel.invokeMethod(_startAdvertisingPeer);
+  FutureOr<dynamic> startAdvertisingPeer({String? deviceName}) async {
+    await _channel.invokeMethod(_startAdvertisingPeer,
+      <String, dynamic>{
+        'deviceName': deviceName ?? "",
+      },
+    );
   }
 
   /// Starts browsing for peers.


### PR DESCRIPTION
Hi,

when we added another plugin into our project (https://github.com/itsMatoosh/geofencing-awesome) the nearby service stopped working under iOS. We are not sure what the exact issue is but the List of found devices never seemed to get sent to the Dart side.

What we did notice was that whenever a peer was lost on iOS the List of devices was suddenly updated. Therefore, we added the `deviceDidChangeState` Notification that is also posted when the device disconnects when a peer is lost.

We didn't know what else to do and also didn't really understand the issue with the 2 plugins running in parallel but this fixed the issue for us.