### PR TITLE
fix: android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.syn_inc.flutter_nearby_connections'
     compileSdkVersion 34
 
     sourceSets {


### PR DESCRIPTION
Android Gradle Plugin(AGP)が8.x.x以上だとbuild.gradleでnamespaceを指定する必要があるので修正。